### PR TITLE
OS X compatibility: syscall.h -> sys/syscall.h

### DIFF
--- a/src/EventAppender.cc
+++ b/src/EventAppender.cc
@@ -34,7 +34,6 @@
 #include <limits>
 #include <cstring>
 #include <unistd.h>
-#include <syscall.h>
 
 #include <log4cxx/helpers/stringhelper.h>
 #include <log4cxx/helpers/pool.h>


### PR DESCRIPTION
OS X does not have syscall.h at the top level; the canonical location seems to be sys/syscall.h (e.g. see http://man7.org/linux/man-pages/man2/syscall.2.html)
