### PR TITLE
DM-5879 Remove use of Boost smart pointers throughout the Science Pipelines

### DIFF
--- a/include/lsst/ctrl/events/Event.h
+++ b/include/lsst/ctrl/events/Event.h
@@ -45,7 +45,6 @@
 #include "lsst/base.h"
 #include "lsst/daf/base/PropertySet.h"
 
-#include "boost/shared_ptr.hpp"
 #include "boost/property_tree/ptree.hpp"
 
 using lsst::daf::base::PropertySet;

--- a/include/lsst/ctrl/events/EventFactory.h
+++ b/include/lsst/ctrl/events/EventFactory.h
@@ -37,7 +37,6 @@
 #include <iostream>
 #include <vector>
 #include <list>
-#include <boost/shared_ptr.hpp>
 
 #include "lsst/base.h"
 #include "lsst/utils/Utils.h"

--- a/include/lsst/ctrl/events/EventLibrary.h
+++ b/include/lsst/ctrl/events/EventLibrary.h
@@ -38,7 +38,6 @@
 #include <iostream>
 #include <vector>
 #include <list>
-#include <boost/shared_ptr.hpp>
 
 namespace lsst {
 namespace ctrl {

--- a/include/lsst/ctrl/events/EventSystem.h
+++ b/include/lsst/ctrl/events/EventSystem.h
@@ -38,7 +38,6 @@
 #include <iostream>
 #include <vector>
 #include <list>
-#include <boost/shared_ptr.hpp>
 
 #include "lsst/daf/base/PropertySet.h"
 

--- a/include/lsst/ctrl/events/LocationId.h
+++ b/include/lsst/ctrl/events/LocationId.h
@@ -35,8 +35,11 @@
 #define LSST_CTRL_EVENTS_LOCATIONID_H
 
 #include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
 
-#include "boost/shared_ptr.hpp"
+#include <string>
+
 
 namespace lsst {
 namespace ctrl {

--- a/include/lsst/ctrl/events/Receiver.h
+++ b/include/lsst/ctrl/events/Receiver.h
@@ -42,8 +42,6 @@
 #include <stdlib.h>
 #include <iostream>
 
-#include <boost/shared_ptr.hpp>
-
 #include "lsst/base.h"
 #include "lsst/utils/Utils.h"
 #include "lsst/daf/base/PropertySet.h"

--- a/python/lsst/ctrl/events/eventsLib.i
+++ b/python/lsst/ctrl/events/eventsLib.i
@@ -38,6 +38,8 @@ Access to the lsst::ctrl::events classes
 
 
 %{
+#include <memory>
+
 #include "lsst/daf/base.h"
 #include "lsst/ctrl/events/Host.h"
 #include "lsst/ctrl/events/LocationId.h"
@@ -101,54 +103,54 @@ Access to the lsst::ctrl::events classes
 %extend lsst::ctrl::events::EventReceiver {
     PTR(lsst::ctrl::events::StatusEvent) receiveStatusEvent() {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent();
-        return boost::static_pointer_cast<lsst::ctrl::events::StatusEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::StatusEvent>(ev);
     }
     PTR(lsst::ctrl::events::StatusEvent) receiveStatusEvent(long timeout) {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent(timeout);
-        return boost::static_pointer_cast<lsst::ctrl::events::StatusEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::StatusEvent>(ev);
     }
     PTR(lsst::ctrl::events::CommandEvent) receiveCommandEvent() {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent();
-        return boost::static_pointer_cast<lsst::ctrl::events::CommandEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::CommandEvent>(ev);
     }
     PTR(lsst::ctrl::events::CommandEvent) receiveCommandEvent(long timeout) {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent(timeout);
-        return boost::static_pointer_cast<lsst::ctrl::events::CommandEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::CommandEvent>(ev);
     }
     PTR(lsst::ctrl::events::LogEvent) receiveLogEvent() {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent();
-        return boost::static_pointer_cast<lsst::ctrl::events::LogEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::LogEvent>(ev);
     }
     PTR(lsst::ctrl::events::LogEvent) receiveLogEvent(long timeout) {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent(timeout);
-        return boost::static_pointer_cast<lsst::ctrl::events::LogEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::LogEvent>(ev);
     }
 }
 
 %extend lsst::ctrl::events::EventDequeuer {
     PTR(lsst::ctrl::events::StatusEvent) receiveStatusEvent() {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent();
-        return boost::static_pointer_cast<lsst::ctrl::events::StatusEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::StatusEvent>(ev);
     }
     PTR(lsst::ctrl::events::StatusEvent) receiveStatusEvent(long timeout) {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent(timeout);
-        return boost::static_pointer_cast<lsst::ctrl::events::StatusEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::StatusEvent>(ev);
     }
     PTR(lsst::ctrl::events::CommandEvent) receiveCommandEvent() {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent();
-        return boost::static_pointer_cast<lsst::ctrl::events::CommandEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::CommandEvent>(ev);
     }
     PTR(lsst::ctrl::events::CommandEvent) receiveCommandEvent(long timeout) {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent(timeout);
-        return boost::static_pointer_cast<lsst::ctrl::events::CommandEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::CommandEvent>(ev);
     }
     PTR(lsst::ctrl::events::LogEvent) receiveLogEvent() {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent();
-        return boost::static_pointer_cast<lsst::ctrl::events::LogEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::LogEvent>(ev);
     }
     PTR(lsst::ctrl::events::LogEvent) receiveLogEvent(long timeout) {
         PTR(lsst::ctrl::events::Event) ev = self->receiveEvent(timeout);
-        return boost::static_pointer_cast<lsst::ctrl::events::LogEvent>(ev);
+        return std::static_pointer_cast<lsst::ctrl::events::LogEvent>(ev);
     }
 }
 

--- a/src/EventSystem.cc
+++ b/src/EventSystem.cc
@@ -31,6 +31,8 @@
  *
  */
 
+#include <memory>
+
 #include "lsst/ctrl/events/EventSystem.h"
 #include "lsst/ctrl/events/EventLibrary.h"
 
@@ -171,11 +173,11 @@ PTR(Receiver) EventSystem::getReceiver(std::string const& name) {
 
 
 PTR(StatusEvent) EventSystem::castToStatusEvent(PTR(Event) event) {
-    return boost::static_pointer_cast<lsst::ctrl::events::StatusEvent>(event);
+    return std::static_pointer_cast<lsst::ctrl::events::StatusEvent>(event);
 }
 
 PTR(CommandEvent) EventSystem::castToCommandEvent(PTR(Event) event) {
-    return boost::static_pointer_cast<lsst::ctrl::events::CommandEvent>(event);
+    return std::static_pointer_cast<lsst::ctrl::events::CommandEvent>(event);
 }
 
 }}}


### PR DESCRIPTION
Makes the following replacements:
- boost::scoped_ptr -> std::unique_ptr
- boost::shared_ptr -> std::shared_ptr
- boost::weak_ptr -> std::weak_ptr
- boost::static_pointer_cast -> std::static_pointer_cast
- boost::dynamic_pointer_cast -> std::dynamic_pointer_cast
- boost::const_pointer_cast -> std::const_pointer_cast
- boost::reinterpret_pointer_cast -> std::reinterpret_pointer_cast
- boost::enamble_shared_from_this -> std::enable_shared_from_this
- boost pointer related includes -> standard library memory
